### PR TITLE
fix: Expose main function to global scope

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -9,4 +9,7 @@ function main() {
   }
 }
 
+// @ts-ignore
+window.main = main;
+
 document.addEventListener('DOMContentLoaded', main);


### PR DESCRIPTION
The main function was not accessible in the global scope, causing a "main is not defined" error when called from the browser console. This commit fixes the issue by attaching the main function to the window object, making it globally available.