### PR TITLE
feat(ci): Run workflow only on pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,6 @@
 name: CI
 
 on:
-  push:
-    branches: [ "**" ]
   pull_request:
     branches: [ "**" ]
   workflow_dispatch:


### PR DESCRIPTION
This PR modifies the CI workflow to run only on pull requests, not on push.